### PR TITLE
Fix compare_values false-positive on None/empty inputs

### DIFF
--- a/src/evaluation/evaluate.py
+++ b/src/evaluation/evaluate.py
@@ -66,12 +66,20 @@ def compare_values(
     Returns (match: bool, method: str) where method describes how the
     match was determined.
     """
+    # Neither value is meaningful — cannot determine a match
+    if golden is None and agent_value is None:
+        return (False, "both_none")
+
     # Convert to strings for exact comparison
     golden_str = str(golden).strip() if golden is not None else ""
     agent_str = str(agent_value).strip() if agent_value is not None else ""
 
+    # One side is empty/None while the other is not — definite mismatch
+    if not golden_str or not agent_str:
+        return (False, "missing_value")
+
     # Exact string match
-    if golden_str and agent_str and golden_str == agent_str:
+    if golden_str == agent_str:
         return (True, "exact_match")
 
     # Numeric comparison


### PR DESCRIPTION
## Summary

`compare_values()` in `src/evaluation/evaluate.py` had two edge-case bugs:

**Bug 1 — `(None, None)` returns `(True, "normalized_match")`**
Both inputs converted to `""`, which then passed the case-insensitive string check `"" == ""`. Two missing values should never count as a match.

**Bug 2 — One `None` value matches a non-empty string**
If `golden=""` and `agent_str="42"`, the exact-match guard `if golden_str and agent_str` was bypassed for the original check but the normalized path could still produce a match.

### Fix
Added two early-exit guards before any string comparison:
```python
if golden is None and agent_value is None:
    return (False, "both_none")
if not golden_str or not agent_str:
    return (False, "missing_value")
```
Also simplified the exact-match check (removed the redundant truthiness guards now that missing values are caught above).

## Test plan
- [ ] `compare_values(None, None)` → `(False, "both_none")`
- [ ] `compare_values("42", None)` → `(False, "missing_value")`
- [ ] `compare_values("42", "42")` → `(True, "exact_match")`
- [ ] `compare_values(3609, "3,609")` → `(True, "numeric_match")`

https://claude.ai/code/session_019aKvkKExRdWN6fBqinkQC3